### PR TITLE
Added support for gender filter tags in backend database / graphql.

### DIFF
--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -61,6 +61,8 @@ module.exports = gql`
     wattsPerKilo: Float!
     intensity: String!
     route: String!
+    women_only: Boolean
+    nonbinary_only: Boolean
     participants: [String]
     match: Int
   }

--- a/models/Event.js
+++ b/models/Event.js
@@ -42,6 +42,12 @@ const eventSchema = new Schema({
         type: String,
         required: true,
     },
+    women_only: {
+        type: Boolean,
+    },
+    nonbinary_only: {
+        type: Boolean,
+    },
     participants: [String],
 });
 


### PR DESCRIPTION
Added women_only and nonbinary_only tags to backend. Not explicitly called at as part of Chainlink-11, but it was necessary for it to work. If someone else has done the same or better work then we can use their branch instead. However, ideally the tag names would stay the same.